### PR TITLE
Fix offset issues and add progress bar

### DIFF
--- a/migration.rb
+++ b/migration.rb
@@ -96,15 +96,17 @@ lite_tables.each do |table|
   # Get total fields from the given table
   total_rows = lite_count(table['name'])
 
-  printf "Migrating #{table['name']} with #{total_rows} records... "
+  puts "Migrating #{table['name']} with #{total_rows} records..."
   i = 0
-  until i > total_rows
+  until i >= total_rows
     rows = []
     lite_select({ table: table['name'], offset: i }).each do |row|
       rows << row
     end
     my_prepare_to_insert({ table: table['name'], columns: columns, rows: rows })
-    i += ENV.fetch('OFFSET').to_i
+
+    i = [i + ENV.fetch('OFFSET').to_i, total_rows].min
+    printf "\33[2K\r#{i}/#{total_rows} (%.2f%%)... ", i.to_f / total_rows * 100
   end
 
   puts 'done'


### PR DESCRIPTION
* The offset doesn't work properly and passing empty "values" to my_insert_data which will cause an sql error.
* Adds a progress bar when running inserts.

The resulting database still won't work properly, and needs further fix by running the SQL queries below, however I'm not sure how to change the script itself to fix it:
```
UPDATE co_art_map SET id = rowid WHERE id IS NULL;
UPDATE co_blockdata_map SET id = rowid WHERE id IS NULL;
UPDATE co_entity_map SET id = rowid WHERE id IS NULL;
UPDATE co_material_map SET id = rowid WHERE id IS NULL;
UPDATE co_world SET id = rowid WHERE id IS NULL;
```


Command outputs with progress bar:
```
$ ruby migration.rb
Truncating co_art_map... done
Migrating co_art_map with 0 records... 
done

Truncating co_block... done
Migrating co_block with 171196 records... 
171196/171196 (100.00%)... done

Truncating co_blockdata_map... done
Migrating co_blockdata_map with 85 records... 
85/85 (100.00%)... done

Truncating co_chat... done
Migrating co_chat with 90 records... 
90/90 (100.00%)... done

Truncating co_command... done
Migrating co_command with 1393 records... 
1393/1393 (100.00%)... done

Truncating co_container... done
Migrating co_container with 44 records... 
44/44 (100.00%)... done

Truncating co_database_lock... done
Migrating co_database_lock with 1 records... 
1/1 (100.00%)... done

Truncating co_entity... done
Migrating co_entity with 1277 records... 
1277/1277 (100.00%)... done

Truncating co_entity_map... done
Migrating co_entity_map with 28 records... 
28/28 (100.00%)... done

Truncating co_item... done
Migrating co_item with 2985 records... 
2985/2985 (100.00%)... done

Truncating co_material_map... done
Migrating co_material_map with 181 records... 
181/181 (100.00%)... done

Truncating co_session... done
Migrating co_session with 828 records... 
828/828 (100.00%)... done

Truncating co_sign... done
Migrating co_sign with 0 records... 
done

Truncating co_skull... done
Migrating co_skull with 0 records... 
done

Truncating co_user... done
Migrating co_user with 50 records... 
50/50 (100.00%)... done

Truncating co_username_log... done
Migrating co_username_log with 31 records... 
31/31 (100.00%)... done

Truncating co_version... done
Migrating co_version with 5 records... 
5/5 (100.00%)... done

Truncating co_world... done
Migrating co_world with 4 records... 
4/4 (100.00%)... done
```